### PR TITLE
Not all WSGI servers pass QUERY_STRING when empty

### DIFF
--- a/dramatiq_dashboard/http.py
+++ b/dramatiq_dashboard/http.py
@@ -42,7 +42,7 @@ class Request:
         return cls(
             method=environ["REQUEST_METHOD"],
             path=environ["PATH_INFO"],
-            params=dict(parse_qsl(environ["QUERY_STRING"])),
+            params=dict(parse_qsl(environ.get("QUERY_STRING", ''))),
             headers=make_request_headers(environ),
             body=environ["wsgi.input"],
         )

--- a/dramatiq_dashboard/http.py
+++ b/dramatiq_dashboard/http.py
@@ -42,7 +42,7 @@ class Request:
         return cls(
             method=environ["REQUEST_METHOD"],
             path=environ["PATH_INFO"],
-            params=dict(parse_qsl(environ.get("QUERY_STRING", ''))),
+            params=dict(parse_qsl(environ.get("QUERY_STRING", ""))),
             headers=make_request_headers(environ),
             body=environ["wsgi.input"],
         )


### PR DESCRIPTION
Fixes:
```python
Traceback (most recent call last):
  File "/opt/test/.venv/lib/python3.7/site-packages/dramatiq_dashboard/http.py", line 106, in __call__
    request = Request.from_environ(environ)
  File "/opt/test/.venv/lib/python3.7/site-packages/dramatiq_dashboard/http.py", line 45, in from_environ
    params=dict(parse_qsl(environ["QUERY_STRING"])),
KeyError: 'QUERY_STRING'
```

Confirmed it works after fixing. Couldn't get it running on the bjoern server without this.