### PR TITLE
Fix `lookup_csrf_token` to handle CSRF cookie that is in the middle of the cookie

### DIFF
--- a/dramatiq_dashboard/csrf.py
+++ b/dramatiq_dashboard/csrf.py
@@ -5,7 +5,7 @@ from threading import local
 from .http import HTTP_403, make_response
 
 _CSRF_COOKIE = "__dd_csrf"
-_CSRF_COOKIE_RE = re.compile(f"{_CSRF_COOKIE}=([^ ]+)")
+_CSRF_COOKIE_RE = re.compile(f"{_CSRF_COOKIE}=([^;]+)")
 _CSRF_STATE = local()
 
 

--- a/dramatiq_dashboard/csrf.py
+++ b/dramatiq_dashboard/csrf.py
@@ -21,7 +21,7 @@ def generate_csrf_token():
 def lookup_csrf_token(request):
     cookies = request.headers.get("cookie")
     if cookies:
-        match = _CSRF_COOKIE_RE.match(cookies)
+        match = _CSRF_COOKIE_RE.search(cookies)
         if match:
             return match.group(1)
 

--- a/dramatiq_dashboard/http.py
+++ b/dramatiq_dashboard/http.py
@@ -47,6 +47,18 @@ class Request:
             body=environ["wsgi.input"],
         )
 
+    @classmethod
+    def test_request(cls, **kwargs):
+        request_data = {
+            'method': 'GET',
+            'path': '/',
+            'params': {},
+            'headers': {},
+            'body': BytesIO(b'')
+        }
+        request_data.update(kwargs)
+        return cls(**request_data)
+
     @property
     def post_data(self):
         if self._post_data is None:

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,19 @@
+import pytest
+
+from dramatiq_dashboard import csrf
+from dramatiq_dashboard.http import Request
+
+TEST_CSRF_TOKEN = csrf.generate_csrf_token()
+
+@pytest.mark.parametrize(
+    "cookie,expected",
+    [
+        (f'{csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN}', TEST_CSRF_TOKEN),
+        (f'some_other_cookie=true {csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN}', TEST_CSRF_TOKEN),
+        (f'{csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN} some_other_cookie=true', TEST_CSRF_TOKEN),
+        (f'the_first_cookie=asdf {csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN} some_other_cookie=true', TEST_CSRF_TOKEN),
+    ]
+)
+def test_lookup_csrf_token(cookie, expected):
+    req = Request.test_request(headers={'cookie': cookie})
+    assert csrf.lookup_csrf_token(req) == expected

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -9,9 +9,9 @@ TEST_CSRF_TOKEN = csrf.generate_csrf_token()
     "cookie,expected",
     [
         (f'{csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN}', TEST_CSRF_TOKEN),
-        (f'some_other_cookie=true {csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN}', TEST_CSRF_TOKEN),
-        (f'{csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN} some_other_cookie=true', TEST_CSRF_TOKEN),
-        (f'the_first_cookie=asdf {csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN} some_other_cookie=true', TEST_CSRF_TOKEN),
+        (f'some_other_cookie=true; {csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN}', TEST_CSRF_TOKEN),
+        (f'{csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN}; some_other_cookie=true', TEST_CSRF_TOKEN),
+        (f'the_first_cookie=asdf; {csrf._CSRF_COOKIE}={TEST_CSRF_TOKEN}; some_other_cookie=true', TEST_CSRF_TOKEN),
     ]
 )
 def test_lookup_csrf_token(cookie, expected):


### PR DESCRIPTION
`re.match` only searches from the beginning of the string, whereas `re.search` will find a match anywhere in the string.