### PR TITLE
Handle url localhost:8070/drama

### DIFF
--- a/dramatiq_dashboard/application.py
+++ b/dramatiq_dashboard/application.py
@@ -63,6 +63,7 @@ class DashboardApp(App):
             "make_uri": make_uri,
         })
 
+        self.add_route("", self.dashboard)
         self.add_route("/", self.dashboard)
         self.add_route("/queues/(?P<name>[^/]+)", self.queue)
         self.add_route("/queues/(?P<name>[^/]+)/(?P<current_tab>(standard|delayed|failed))", self.queue)
@@ -153,4 +154,5 @@ class DashboardApp(App):
 
     @handler
     def not_found(self, req):
-        return HTTP_404, "Not Found"
+        path=req.get('path', None)
+        return HTTP_404, f"dramatiq_dashboard: path {path} not found"


### PR DESCRIPTION
When using the dashboard the url `localhost:8070/drama` would return a `Not found` because it was picked up by `dramatiq`, but not handled. This PR allows usage of both `localhost:8070/drama` and `localhost:8070/drama/`. It also gives a slighly more informative error message for urls that are not handled.

@Bogdanp 