### PR TITLE
Allow Redis 4.x in dramatiq_dashboard

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ dependencies = [
     "dataclasses; python_version < '3.7'",
     "dramatiq[redis]>=1.6,<2.0",
     "jinja2>=2,<3",
-    "redis>=2.0,<4.0",
+    "redis>=2.0,<5.0",
 ]
 
 extra_dependencies = {


### PR DESCRIPTION
@Bogdanp this blocks us from bumping Redis to 4.x in the API project that have both Dramatiq and Dramatiq Dashboard as the dependency.