### PR TITLE
Add dependency support for Jinja2 version 3

### DIFF
--- a/examples/basic/app.py
+++ b/examples/basic/app.py
@@ -37,11 +37,7 @@ def start(uri: QueryParam):
     return "Message sent!"
 
 
-app = App(
-    routes=[
-        Route("/crawl", start)
-    ]
-)
+app = App(routes=[Route("/crawl", start)])
 
 dashboard_middleware = dramatiq_dashboard.make_wsgi_middleware("/drama")
 app = dashboard_middleware(app)

--- a/examples/basic/requirements.txt
+++ b/examples/basic/requirements.txt
@@ -2,3 +2,5 @@ dramatiq[redis,watch]
 dramatiq_dashboard
 gunicorn
 molten
+markupsafe==2.0.1
+jinja2==3.0.3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(rel("dramatiq_dashboard", "__init__.py"), "r") as f:
 dependencies = [
     "dataclasses; python_version < '3.7'",
     "dramatiq[redis]>=1.6,<2.0",
-    "jinja2>=2,>=3",
+    "jinja2>=2",
     "redis>=2.0,<5.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,11 @@ with open(rel("dramatiq_dashboard", "__init__.py"), "r") as f:
 dependencies = [
     "dataclasses; python_version < '3.7'",
     "dramatiq[redis]>=1.6,<2.0",
-    "jinja2>=2,<3",
+    "jinja2>=2,>=3",
     "redis>=2.0,<5.0",
 ]
 
-extra_dependencies = {
-}
+extra_dependencies = {}
 
 extra_dependencies["all"] = list(set(sum(extra_dependencies.values(), [])))
 extra_dependencies["dev"] = extra_dependencies["all"] + [
@@ -38,19 +37,16 @@ extra_dependencies["dev"] = extra_dependencies["all"] + [
     "alabaster",
     "sphinx<1.8",
     "sphinxcontrib-napoleon",
-
     # Linting
     "flake8",
     "flake8-bugbear",
     "flake8-quotes",
     "isort",
-
     # Misc
     "bumpversion",
     "hiredis",
     "twine",
     "wheel",
-
     # Testing
     "pytest",
     "pytest-benchmark[histogram]",
@@ -66,9 +62,7 @@ setup(
     description="A dashboard for Dramatiq (Redis-only!).",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=[
-        "dramatiq_dashboard"
-    ],
+    packages=["dramatiq_dashboard"],
     include_package_data=True,
     install_requires=dependencies,
     python_requires=">=3.6",


### PR DESCRIPTION
Was able to test the basic example provided in this repo to verify that the dashboard renders fine with the latest Jinja2 version 3.x (https://jinja.palletsprojects.com/en/3.0.x/changes/).  I did need to pin `marksafe` in the basic example (context here: https://github.com/pallets/markupsafe/issues/284).

I'm not sure if there was a specific version originally that you had pinned `jinja` < version 3