### PR TITLE
Use supported redis versions from main dramatiq package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ dependencies = [
     "dataclasses; python_version < '3.7'",
     "dramatiq[redis]>=1.6,<2.0",
     "jinja2>=2",
-    "redis>=2.0,<5.0",
 ]
 
 extra_dependencies = {}


### PR DESCRIPTION
Adds support for v5.x of the redis package.

Alternative to #22.