### PR TITLE
Update supported python versions

### DIFF
--- a/dramatiq_dashboard/http.py
+++ b/dramatiq_dashboard/http.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass, field
 from io import BytesIO
-from typing import Dict, Union
+from typing import Union
 from urllib.parse import parse_qsl
 
 HTTP_200 = "200 OK"
@@ -31,11 +31,11 @@ def make_request_headers(environ):
 class Request:
     method: str
     path: str
-    params: Dict[str, str]
-    headers: Dict[str, str]
+    params: dict[str, str]
+    headers: dict[str, str]
     body: BytesIO
 
-    _post_data: Dict[str, str] = None
+    _post_data: dict[str, str] = None
 
     @classmethod
     def from_environ(cls, environ):

--- a/setup.py
+++ b/setup.py
@@ -64,10 +64,9 @@ setup(
     packages=["dramatiq_dashboard"],
     include_package_data=True,
     install_requires=dependencies,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     extras_require=extra_dependencies,
     classifiers=[
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: System :: Distributed Computing",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",  # FIXME

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: System :: Distributed Computing",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",  # FIXME

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: System :: Distributed Computing",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",  # FIXME

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: System :: Distributed Computing",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",  # FIXME

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(rel("README.md")) as f:
     long_description = f.read()
 
 
-with open(rel("dramatiq_dashboard", "__init__.py"), "r") as f:
+with open(rel("dramatiq_dashboard", "__init__.py")) as f:
     version_marker = "__version__ = "
     for line in f:
         if line.startswith(version_marker):
@@ -23,7 +23,6 @@ with open(rel("dramatiq_dashboard", "__init__.py"), "r") as f:
 
 
 dependencies = [
-    "dataclasses; python_version < '3.7'",
     "dramatiq[redis]>=1.6,<2.0",
     "jinja2>=2",
     "redis>=2.0,<5.0",
@@ -65,10 +64,9 @@ setup(
     packages=["dramatiq_dashboard"],
     include_package_data=True,
     install_requires=dependencies,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     extras_require=extra_dependencies,
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -64,10 +64,9 @@ setup(
     packages=["dramatiq_dashboard"],
     include_package_data=True,
     install_requires=dependencies,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     extras_require=extra_dependencies,
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: System :: Distributed Computing",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",  # FIXME

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: System :: Distributed Computing",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",  # FIXME


### PR DESCRIPTION
Lists support for current python versions, and removes support for now end-of-life versions. Also runs [`pyupgrade==3.20.0`](https://github.com/asottile/pyupgrade) after each version drop.