### PR TITLE
feat: expose dramatiq global metrics as JSON

### DIFF
--- a/dramatiq_dashboard/application.py
+++ b/dramatiq_dashboard/application.py
@@ -1,3 +1,4 @@
+import json
 from pprint import pformat
 from urllib.parse import urlencode
 
@@ -6,7 +7,7 @@ from dramatiq.common import dq_name, q_name, xq_name
 
 from .csrf import csrf_protect, render_csrf_token
 from .filters import isoformat, short, timeago
-from .http import HTTP_404, HTTP_405, HTTP_410, App, handler, redirect, templated
+from .http import HTTP_404, HTTP_405, HTTP_410, App, Response, handler, redirect, templated
 from .interface import Job, RedisInterface
 
 
@@ -64,6 +65,7 @@ class DashboardApp(App):
         })
 
         self.add_route("/", self.dashboard)
+        self.add_route("/metrics", self.metrics)
         self.add_route("/queues/(?P<name>[^/]+)", self.queue)
         self.add_route("/queues/(?P<name>[^/]+)/(?P<current_tab>(standard|delayed|failed))", self.queue)
         self.add_route("/queues/(?P<name>[^/]+)/(?P<current_tab>(standard|delayed|failed))/(?P<message_id>[^/]+)", self.job)
@@ -71,6 +73,17 @@ class DashboardApp(App):
         self.add_route("/requeue-message", self.requeue_message)
         self.add_route(".*", self.not_found)
 
+    @handler
+    def metrics(self, req):
+        data = {
+            "queues": self.iface.queues,
+            "workers": self.iface.workers
+        }
+        return Response(
+            content=json.dumps(data),
+            headers=[("Content-Type", "application/json")]
+        )
+    
     @handler
     @templated("dashboard.html")
     def dashboard(self, req):

--- a/dramatiq_dashboard/application.py
+++ b/dramatiq_dashboard/application.py
@@ -1,6 +1,7 @@
 import json
 from pprint import pformat
 from urllib.parse import urlencode
+from dataclasses import asdict
 
 import jinja2
 from dramatiq.common import dq_name, q_name, xq_name
@@ -76,8 +77,8 @@ class DashboardApp(App):
     @handler
     def metrics(self, req):
         data = {
-            "queues": self.iface.queues,
-            "workers": self.iface.workers
+            "queues": [asdict(q) for q in self.iface.queues],
+            "workers": [asdict(w) for w in self.iface.workers],
         }
         return Response(
             content=json.dumps(data),

--- a/dramatiq_dashboard/application.py
+++ b/dramatiq_dashboard/application.py
@@ -81,7 +81,7 @@ class DashboardApp(App):
             "workers": [asdict(w) for w in self.iface.workers],
         }
         return Response(
-            content=json.dumps(data),
+            content=json.dumps(data, default=str),
             headers=[("Content-Type", "application/json")]
         )
     

--- a/dramatiq_dashboard/application.py
+++ b/dramatiq_dashboard/application.py
@@ -76,9 +76,16 @@ class DashboardApp(App):
 
     @handler
     def metrics(self, req):
+        queues_serialized = [asdict(q) for q in self.iface.queues]
+        workers_serialized = [asdict(w) for w in self.iface.workers]
         data = {
-            "queues": [asdict(q) for q in self.iface.queues],
-            "workers": [asdict(w) for w in self.iface.workers],
+            "global_stats": {
+                "jobs": sum(q["jobs"] for q in queues_serialized),
+                "jobs_delayed": sum(q["jobs_delayed"] for q in queues_serialized),
+                "jobs_dead": sum(q["jobs_dead"] for q in queues_serialized),
+            },
+            "queues": queues_serialized,
+            "workers": workers_serialized,
         }
         return Response(
             content=json.dumps(data, default=str),

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ dependencies = [
     "dataclasses; python_version < '3.7'",
     "dramatiq[redis]>=1.6,<2.0",
     "jinja2>=2",
-    "redis>=2.0,<5.0",
+    "redis>=2.0,<7.0",
 ]
 
 extra_dependencies = {}


### PR DESCRIPTION
Expose dramatiq metrics as an easy to parse JSON on `GET /metrics`

The response JSON looks like:

```
{
  "global_stats": {
    "jobs": 0,
    "jobs_delayed": 0,
    "jobs_dead": 0
  },
  "queues": [
    {
      "name": "default",
      "jobs": 0,
      "jobs_delayed": 0,
      "jobs_dead": 0
    }
  ],
  "workers": [
    {
      "name": "062df319-7365-4b83-bb1f-062d3433b691",
      "last_seen": "2025-11-19 11:35:51.443000",
      "jobs_in_flight": 0
    },
    {
      "name": "bcb8dc49-2c34-406f-a006-02e435462a32",
      "last_seen": "2025-11-19 11:36:19.188000",
      "jobs_in_flight": 0
    }
  ]
}
```

Same as the variables used in the dashboard endpoint (`GET /`) but as a JSON response, plus the global_stats, which is just a sum over all the queues where dramatiq is listening to.

This should be easy to fetch to build a metrics dashboard that displays the global number of jobs in the system.

Useful if you want to add triggers on global stats (auto-scale, etc.)